### PR TITLE
perf: tune timing of message publish

### DIFF
--- a/mqtt/mosquitto/config/mosquitto.conf
+++ b/mqtt/mosquitto/config/mosquitto.conf
@@ -4,3 +4,4 @@ listener 9001
 protocol websockets
 certfile /mosquitto/cert/primary.crt
 keyfile /mosquitto/cert/private.pem
+retry_interval 1

--- a/web/index.ts
+++ b/web/index.ts
@@ -14,7 +14,8 @@ import {
   mapTo,
   map,
   startWith,
-  distinctUntilChanged
+  distinctUntilChanged,
+  debounceTime
 } from 'rxjs/operators';
 import { RobotController } from './robot';
 import { createTopic$ } from './topic';
@@ -310,8 +311,9 @@ const setupUI = async () => {
 
   startClick$
     .pipe(
-      switchMap(_ => interval(300).pipe(takeUntil(stopClick$))),
-      flatMap(_ => from(predict()))
+      switchMap(_ => interval(100).pipe(takeUntil(stopClick$))),
+      flatMap(_ => from(predict())),
+      distinctUntilChanged()
     )
     .subscribe(predictionResultSubject);
 
@@ -325,12 +327,17 @@ const setupUI = async () => {
     }
   });
 
-  predictionResultSubject.subscribe(label => {
-    if (label !== null) {
-      const velocity = label - 1; // label to velocity
-      robotController.setVelocity(velocity);
-    }
-  });
+  predictionResultSubject
+    .pipe(
+      debounceTime(100),
+      distinctUntilChanged()
+    )
+    .subscribe(label => {
+      if (label !== null) {
+        const velocity = label - 1; // label to velocity
+        robotController.setVelocity(velocity);
+      }
+    });
 
   activeCameraSideSubject.subscribe(side => {
     resetAll();

--- a/web/index.ts
+++ b/web/index.ts
@@ -329,7 +329,7 @@ const setupUI = async () => {
 
   predictionResultSubject
     .pipe(
-      debounceTime(100),
+      debounceTime(150),
       distinctUntilChanged()
     )
     .subscribe(label => {


### PR DESCRIPTION
MQTTサーバにメッセージをたくさん送るとロボットの動作が不安定になる問題がありましたので，以下のように変更します。

従来: 一定時間間隔でメッセージを送信
提案: 顔が変わった時に送信。但し，100msの間の変更は最新の変更のみ送信 (debounce)。

debounceTimeについては[こちら](http://rxmarbles.com/#debounceTime) を参照下さい。