### PR TITLE
Feature 63

### DIFF
--- a/robot/raspberrypi_client/mqtt_client.py
+++ b/robot/raspberrypi_client/mqtt_client.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from enum import Enum
 import RPi.GPIO as GPIO
 import signal
@@ -66,10 +67,10 @@ class MQTTClient(object):
         self.client.on_message = self.on_message
         # self.client.on_disconnect = self.on_disconnect
         self.robot_name = robot_name
-        self.right_servo = Servo(gpio_number=17, wheel=Wheel.RIGHT)
-        self.left_servo = Servo(gpio_number=27, wheel=Wheel.LEFT)
+        self.right_servo = Servo(gpio_number=3, wheel=Wheel.RIGHT)
+        self.left_servo = Servo(gpio_number=4, wheel=Wheel.LEFT)
         # setup GPIO for LED
-        self.led_connect = Led(26)
+        self.led_connect = Led(24)
         self.led_message = Led(21)
         self.server_host = server_host
 
@@ -119,6 +120,10 @@ def main():
     client_args = p.parse_args()
 
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    fh = logging.FileHandler('client.log')
+    fh.formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s')
+
+    logger.addHandler(fh)
 
     m_client = MQTTClient(client_args.name, client_args.server)
     signal.signal(signal.SIGINT, m_client.signal_handler)

--- a/robot/raspberrypi_client/mqtt_client.py
+++ b/robot/raspberrypi_client/mqtt_client.py
@@ -120,10 +120,6 @@ def main():
     client_args = p.parse_args()
 
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
-    fh = logging.FileHandler('client.log')
-    fh.formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s')
-
-    logger.addHandler(fh)
 
     m_client = MQTTClient(client_args.name, client_args.server)
     signal.signal(signal.SIGINT, m_client.signal_handler)

--- a/robot/raspberrypi_client/mqttclient.service
+++ b/robot/raspberrypi_client/mqttclient.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = mqtt client for makerfairetokyo 2018
+
+[Service]
+ExecStart = /home/pi/makerFaireTokyo2018/mqtt_client.py
+Restart = always
+Type = simple
+
+[Install]
+WantedBy = multi-user.target

--- a/robot/raspberrypi_client/mqttclient_reset.service
+++ b/robot/raspberrypi_client/mqttclient_reset.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = reset mqtt client for makerfairetokyo 2018
+
+[Service]
+ExecStart = /home/pi/makerFaireTokyo2018/reset.py
+Restart = always
+Type = simple
+
+[Install]
+WantedBy = multi-user.target

--- a/robot/raspberrypi_client/requirements.txt
+++ b/robot/raspberrypi_client/requirements.txt
@@ -1,0 +1,3 @@
+enum
+paho-mqtt
+RPi.GPIO

--- a/robot/raspberrypi_client/reset.py
+++ b/robot/raspberrypi_client/reset.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import RPi.GPIO as GPIO
+from time import sleep
+import subprocess
+import logging
+import signal
+
+logger = logging.getLogger(__name__)
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(10, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+
+
+def loop():
+    while True:
+        if GPIO.input(10) == GPIO.HIGH:
+            logger.info("restart")
+            logger.info("result_code: {}".format(subprocess.call(["sudo", "systemctl", "restart", "mqttclient"])))
+            sleep(2)
+        sleep(1)
+
+
+def signal_handler(number, frame):
+    GPIO.cleanup()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    fh = logging.FileHandler('/var/log/reset.log')
+    fh.formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s')
+
+    logger.addHandler(fh)
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    loop()
+
+
+main()

--- a/robot/raspberrypi_client/reset.py
+++ b/robot/raspberrypi_client/reset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import RPi.GPIO as GPIO
 from time import sleep
+import RPi.GPIO as GPIO
 import subprocess
 import logging
 import signal
@@ -26,10 +26,6 @@ def signal_handler(number, frame):
 
 def main():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
-    fh = logging.FileHandler('/var/log/reset.log')
-    fh.formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s')
-
-    logger.addHandler(fh)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 


### PR DESCRIPTION
- systemdを使って、mqtt_clientを自動起動するようにしました
 - mqtt_clientのログは/var/log/syslogか journalctlコマンドで確認が出来ます。
- リセットボタンが押されたときに、mqtt_clientのサービスをリセットするreset.pyを追加しました。reset.pyもsystemdで自動起動するようになっています。
- 配線関係で、サーボやLEDのgpioのピン番号を変更しました