### PR TITLE
feat: share image during play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ robot/esp8266_client/setting.h
 *.pem
 
 !.gitkeep
+
+.env

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npx mqtt sub -t 'nobunaga/left' -h 'localhost'
 ## Dropbox との連携
 
 プレイ画像を共有する機能を有効にするには、 Dropbox との連携が必要です。
-https://www.dropbox.com/developers/apps?_tk=pilot_lp&_ad=topbar4&_camp=myapps からアプリを作成し、プロジェクトの直下に `.env` というファイルを作成して以下のような内容を記載してください。 
+https://www.dropbox.com/developers/apps からアプリを作成し、プロジェクトの直下に `.env` というファイルを作成して以下のような内容を記載してください。 
 
 ```
 DROPBOX_ACCESS_TOKEN={{ アプリのアクセストークン }}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ $ npm run mqtt # run MQTT server on Docker
 # If you want to subscribe to a topic ('nobunaga/left', for example)
 $ npx mqtt sub -t 'nobunaga/left' -h 'localhost'
 ```
+
+## Dropbox との連携
+
+プレイ画像を共有する機能を有効にするには、 Dropbox との連携が必要です。
+https://www.dropbox.com/developers/apps?_tk=pilot_lp&_ad=topbar4&_camp=myapps からアプリを作成し、プロジェクトの直下に `.env` というファイルを作成して以下のような内容を記載してください。 
+
+```
+DROPBOX_ACCESS_TOKEN={{ アプリのアクセストークン }}
+DROPBOX_FOLDER_NAME={{ プレイ画像を保存するフォルダ }}
+```
+
+この機能では、 Dropbox API により、保存したプレイ画像に 4 時間だけアクセス可能な URL が生成され、それが QR コードとして画面上に表示されます。

--- a/package-lock.json
+++ b/package-lock.json
@@ -7381,6 +7381,11 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
+    "qrcodejs2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/qrcodejs2/-/qrcodejs2-0.0.2.tgz",
+      "integrity": "sha1-Rlr+Xjnxn6zsuTLBH3oYYQkUauE="
+    },
     "query-string": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tensorflow/tfjs": "^0.11.6",
     "mqtt": "^2.18.1",
     "node-fetch": "^2.1.2",
+    "qrcodejs2": "0.0.2",
     "rxjs": "^6.2.1",
     "tslib": "^1.9.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,15 +6,18 @@
     "module": "es2015",
     "moduleResolution": "node",
     "noEmitOnError": true,
+    "downlevelIteration": true,
     "lib": [
       "es2017",
-      "dom"
+      "dom",
+      "dom.iterable"
     ],
     "strict": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "node_modules"

--- a/web/imageRecorder.ts
+++ b/web/imageRecorder.ts
@@ -215,7 +215,7 @@ export class ImageRecorder {
   private async writeSingleImageOnViewer(imageSrc: string) {
     const ctx = this.viewer.getContext('2d')!;
     const left = 176;
-    const top = 72;
+    const top = 80;
     this.resetBackground(ctx);
     ctx.strokeStyle = 'rgb(32, 202, 117)';
     ctx.lineWidth = 3;
@@ -238,7 +238,7 @@ export class ImageRecorder {
   private async writeTwoImagesOnViewer(leftSrc: string, rightSrc: string) {
     const ctx = this.viewer.getContext('2d')!;
     const left = 32;
-    const top = 72;
+    const top = 80;
     this.resetBackground(ctx);
     ctx.strokeStyle = 'rgb(32, 202, 117)';
     ctx.lineWidth = 3;
@@ -296,12 +296,12 @@ export class ImageRecorder {
     ctx.shadowBlur = 8;
     ctx.shadowColor = ctx.fillStyle;
     ctx.textAlign = 'center';
-    ctx.fillText('ガンメンタイセン', this.viewer.width / 2, 32);
+    ctx.fillText('ガンメンタイセン', this.viewer.width / 2, 40);
 
     ctx.font = '16px PixelMPlus';
     ctx.fillStyle = '#F4AF4C';
     ctx.shadowColor = ctx.fillStyle;
-    ctx.fillText('カブク @Maker Faire Tokyo 2018', this.viewer.width / 2, 56);
+    ctx.fillText('カブク @Maker Faire Tokyo 2018', this.viewer.width / 2, 64);
   }
 
   private loadImage(image: string): Promise<HTMLImageElement> {

--- a/web/imageRecorder.ts
+++ b/web/imageRecorder.ts
@@ -1,0 +1,315 @@
+import { Subject, fromEvent } from 'rxjs';
+import { throttleTime } from 'rxjs/operators';
+
+const QRCode = require('qrcodejs2');
+
+export class ImageRecorder {
+  readonly images$ = new Subject<
+    [HTMLCanvasElement] | [HTMLCanvasElement, HTMLCanvasElement]
+  >();
+  private _recordedImages: ReadonlyArray<[string] | [string, string]> = [];
+  private _selectedIndex = 0;
+  private _hideLeft = false;
+  private _hideRight = false;
+  private readonly recordsButton = document.querySelector('.show-records')!;
+  private readonly clearRecordsButton = document.querySelector(
+    '.clear-records'
+  )!;
+  private readonly modal = document.querySelector('.modal')!;
+  private readonly overlay = document.querySelector('.overlay')!;
+  private readonly previousImageButton = document.querySelector(
+    '.previous-image'
+  )! as HTMLButtonElement;
+  private readonly nextImageButton = document.querySelector(
+    '.next-image'
+  )! as HTMLButtonElement;
+  private readonly toggleLeftButton = document.querySelector(
+    '.toggle-left-image'
+  );
+  private readonly toggleRightButton = document.querySelector(
+    '.toggle-right-image'
+  );
+  private readonly shareButton = document.querySelector('.share-image')!;
+  private readonly closeQRCodeButton = document.querySelector('.close-qrcode')!;
+  private readonly viewer = document.querySelector(
+    '.recorded-image-viewer'
+  )! as HTMLCanvasElement;
+
+  private readonly qrCode = new QRCode(document.querySelector('.image-qrcode'));
+
+  constructor(private readonly imageSize: number) {
+    // record image every 10 seconds
+    this.images$.pipe(throttleTime(10000)).subscribe(images => {
+      this.recordedImages = [
+        ...this.recordedImages,
+        images.map(image => image.toDataURL()) as [string] | [string, string]
+      ];
+    });
+
+    // show recorded images on modal
+    fromEvent(this.recordsButton, 'click').subscribe(e => {
+      e.preventDefault();
+      this.selectedIndex = 0;
+      this.overlay.classList.remove('hidden');
+    });
+
+    // close modal
+    fromEvent(this.overlay, 'click').subscribe(({ target, currentTarget }) => {
+      if (target === currentTarget) {
+        this.overlay.classList.add('hidden');
+        this.modal.classList.remove('display-qrcode');
+      }
+    });
+
+    // clear recorded images
+    fromEvent(this.clearRecordsButton, 'click').subscribe(e => {
+      e.preventDefault();
+      this.recordedImages = [];
+    });
+
+    // go back and forth on modal
+    fromEvent(this.previousImageButton, 'click').subscribe(
+      () => (this.selectedIndex -= 1)
+    );
+    fromEvent(this.nextImageButton, 'click').subscribe(
+      () => (this.selectedIndex += 1)
+    );
+
+    // toggle display state of images
+    this.toggleLeftButton &&
+      fromEvent(this.toggleLeftButton, 'click').subscribe(
+        () => (this.hideLeft = !this.hideLeft)
+      );
+    this.toggleRightButton &&
+      fromEvent(this.toggleRightButton, 'click').subscribe(
+        () => (this.hideRight = !this.hideRight)
+      );
+
+    // share image
+    fromEvent(this.shareButton, 'click').subscribe(async () => {
+      this.shareButton.classList.add('loading');
+      try {
+        const blob = await new Promise<Blob>(resolve =>
+          this.viewer.toBlob(blob => resolve(blob!))
+        );
+        const { name } = await fetch(
+          'https://content.dropboxapi.com/2/files/upload',
+          {
+            body: blob,
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${process.env.DROPBOX_ACCESS_TOKEN}`,
+              'Content-Type': 'application/octet-stream',
+              'Dropbox-API-Arg': JSON.stringify({
+                path: `/${process.env.DROPBOX_FOLDER_NAME}/image.png`,
+                autorename: true
+              })
+            }
+          }
+        ).then(
+          async res =>
+            res.ok ? res.json() : Promise.reject(new Error(await res.text()))
+        );
+        const { link } = await fetch(
+          'https://api.dropboxapi.com/2/files/get_temporary_link',
+          {
+            body: JSON.stringify({
+              path: `/${process.env.DROPBOX_FOLDER_NAME}/${name}`
+            }),
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${process.env.DROPBOX_ACCESS_TOKEN}`,
+              'Content-Type': 'application/json'
+            }
+          }
+        ).then(
+          async res =>
+            res.ok ? res.json() : Promise.reject(new Error(await res.text()))
+        );
+        this.qrCode.makeCode(link);
+        this.modal.classList.add('display-qrcode');
+      } catch (e) {
+        console.error(e);
+        alert('Failed! Open console for detail.');
+      }
+      this.shareButton.classList.remove('loading');
+    });
+    fromEvent(this.closeQRCodeButton, 'click').subscribe(() => {
+      this.qrCode.clear();
+      this.modal.classList.remove('display-qrcode');
+    });
+  }
+
+  private get recordedImages(): ReadonlyArray<[string] | [string, string]> {
+    return this._recordedImages;
+  }
+
+  private set recordedImages(
+    recordedImages: ReadonlyArray<[string] | [string, string]>
+  ) {
+    this.toggleRecordButtonsDisabled(recordedImages);
+    this._recordedImages = recordedImages;
+  }
+
+  private toggleRecordButtonsDisabled(
+    recordedImages: ReadonlyArray<[string] | [string, string]>
+  ): void {
+    [this.recordsButton, this.clearRecordsButton].forEach(button =>
+      button.classList.toggle('disabled', recordedImages.length === 0)
+    );
+  }
+
+  private get selectedIndex(): number {
+    return this._selectedIndex;
+  }
+  private set selectedIndex(selectedIndex: number) {
+    if (selectedIndex < 0) {
+      selectedIndex = this.recordedImages.length - 1;
+    }
+    if (selectedIndex >= this.recordedImages.length) {
+      selectedIndex = 0;
+    }
+    this._selectedIndex = selectedIndex;
+    this.writeImageOnViewer();
+  }
+
+  private get hideLeft(): boolean {
+    return this._hideLeft;
+  }
+  private set hideLeft(hideLeft: boolean) {
+    if (hideLeft && this._hideRight) {
+      this._hideRight = false;
+      this.modal.classList.remove('hide-right-image');
+    }
+    this.modal.classList.toggle('hide-left-image', hideLeft);
+    this._hideLeft = hideLeft;
+    this.writeImageOnViewer();
+  }
+
+  private get hideRight(): boolean {
+    return this._hideRight;
+  }
+  private set hideRight(hideRight: boolean) {
+    if (hideRight && this._hideLeft) {
+      this._hideLeft = false;
+      this.modal.classList.remove('hide-left-image');
+    }
+    this.modal.classList.toggle('hide-right-image', hideRight);
+    this._hideRight = hideRight;
+    this.writeImageOnViewer();
+  }
+
+  private writeImageOnViewer() {
+    const images = this.recordedImages[this.selectedIndex];
+    if (images.length === 1 || this.hideRight) {
+      this.writeSingleImageOnViewer(images[0]).catch(e => console.error(e));
+    } else if (this.hideLeft) {
+      this.writeSingleImageOnViewer(images[1]).catch(e => console.error(e));
+    } else {
+      this.writeTwoImagesOnViewer(images[0], images[1]).catch(e =>
+        console.error(e)
+      );
+    }
+  }
+
+  private async writeSingleImageOnViewer(imageSrc: string) {
+    const ctx = this.viewer.getContext('2d')!;
+    const left = 176;
+    const top = 72;
+    this.resetBackground(ctx);
+    ctx.strokeStyle = 'rgb(32, 202, 117)';
+    ctx.lineWidth = 3;
+    ctx.shadowBlur = 20;
+    ctx.shadowColor = ctx.strokeStyle;
+    const halfLineWidth = ctx.lineWidth / 2;
+    ctx.rect(
+      left - halfLineWidth,
+      top - halfLineWidth,
+      this.imageSize + ctx.lineWidth,
+      this.imageSize + ctx.lineWidth
+    );
+    ctx.stroke();
+
+    ctx.scale(-1, 1);
+    ctx.drawImage(await this.loadImage(imageSrc), -left - this.imageSize, top);
+    ctx.scale(-1, 1);
+  }
+
+  private async writeTwoImagesOnViewer(leftSrc: string, rightSrc: string) {
+    const ctx = this.viewer.getContext('2d')!;
+    const left = 32;
+    const top = 72;
+    this.resetBackground(ctx);
+    ctx.strokeStyle = 'rgb(32, 202, 117)';
+    ctx.lineWidth = 3;
+    ctx.shadowBlur = 20;
+    ctx.shadowColor = ctx.strokeStyle;
+    const halfLineWidth = ctx.lineWidth / 2;
+    ctx.rect(
+      left - halfLineWidth,
+      top - halfLineWidth,
+      this.imageSize + ctx.lineWidth,
+      this.imageSize + ctx.lineWidth
+    );
+    ctx.stroke();
+    ctx.rect(
+      left + this.viewer.width / 2 - halfLineWidth,
+      top - halfLineWidth,
+      this.imageSize + ctx.lineWidth,
+      this.imageSize + ctx.lineWidth
+    );
+    ctx.stroke();
+
+    ctx.scale(-1, 1);
+    ctx.drawImage(await this.loadImage(leftSrc), -left - this.imageSize, top);
+    ctx.drawImage(
+      await this.loadImage(rightSrc),
+      -left - this.viewer.width / 2 - this.imageSize,
+      top
+    );
+    ctx.scale(-1, 1);
+  }
+
+  private resetBackground(ctx: CanvasRenderingContext2D): void {
+    ctx.clearRect(0, 0, this.viewer.width, this.viewer.height);
+    ctx.beginPath();
+
+    let x = 0;
+    while (x < this.viewer.width) {
+      const gradient = ctx.createLinearGradient((x += 10), 0, 1, 0);
+      gradient.addColorStop(0, '#08223d');
+      gradient.addColorStop(1, 'transparent');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(x, 0, 1, this.viewer.height);
+    }
+    let y = 0;
+    while (y < this.viewer.height) {
+      const gradient = ctx.createLinearGradient(0, (y += 10), 0, 1);
+      gradient.addColorStop(0, '#08223d');
+      gradient.addColorStop(1, 'transparent');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, y, this.viewer.width, 1);
+    }
+
+    ctx.font = '32px PixelMPlus';
+    ctx.fillStyle = '#53FFE2';
+    ctx.shadowBlur = 8;
+    ctx.shadowColor = ctx.fillStyle;
+    ctx.textAlign = 'center';
+    ctx.fillText('ガンメンタイセン', this.viewer.width / 2, 32);
+
+    ctx.font = '16px PixelMPlus';
+    ctx.fillStyle = '#F4AF4C';
+    ctx.shadowColor = ctx.fillStyle;
+    ctx.fillText('カブク @Maker Faire Tokyo 2018', this.viewer.width / 2, 56);
+  }
+
+  private loadImage(image: string): Promise<HTMLImageElement> {
+    const img = new Image();
+    const result = new Promise<HTMLImageElement>(
+      resolve => (img.onload = () => resolve(img))
+    );
+    img.src = image;
+    return result;
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -12,10 +12,16 @@
 
     <h1>ガンメンタイセン</h1>
 
-    <nav class="links">
-      <a href="index.html">1P</a>
-      <a href="pairplay.html">2P</a>
-    </nav>
+    <div class="menu">
+      <nav class="links">
+        <a href="index.html">1P</a>
+        <a href="pairplay.html">2P</a>
+      </nav>
+      <p class="records-container">
+        <a class="show-records disabled" href="#">タタカイノキロク</a>
+        <a class="clear-records disabled" href="#">（消去）</a>
+      </p>
+    </div>
 
     <select id="camera-selector"></select>
 
@@ -54,8 +60,25 @@
       </div>
 
     </main>
-
-    <script src="./index.ts"></script>
+  </div>
+  <div class="overlay hidden">
+    <div class="modal">
+      <button class="previous-image" type="button">&lt;</button>
+      <button class="next-image" type="button">&gt;</button>
+      <div class="modal-footer">
+        <button class="toggle-left-image">Left</button>
+        <button class="share-image">
+          Share
+          <div class="loading-ring"></div>
+        </button>
+        <button class="toggle-right-image">Right</button>
+        <button class="close-qrcode">Back</button>
+      </div>
+      <canvas class="recorded-image-viewer" width="576" height="324"></canvas>
+      <div class="image-qrcode"></div>
+    </div>
+  </div>
+  <script src="./index.ts"></script>
 </body>
 
 </html>

--- a/web/index.ts
+++ b/web/index.ts
@@ -35,6 +35,7 @@ import { createPressStream, loadMobilenet } from './helper';
 
 import './styles.css';
 import './oneside.css';
+import { ImageRecorder } from './imageRecorder';
 
 const imageSize = 224;
 
@@ -158,6 +159,8 @@ const setupUI = async () => {
   const startClick$ = fromEvent(startPredictButton, 'click');
   const stopClick$ = fromEvent(stopPredictButton, 'click');
 
+  const imageRecorder = new ImageRecorder(imageSize);
+
   startClick$
     .pipe(
       tap(_ => classifier.setControlStatus(ControlStatus.Started)),
@@ -171,6 +174,7 @@ const setupUI = async () => {
           activeSide,
           cropArea
         );
+        imageRecorder.images$.next([destImage]);
         return from(classifier.predict(image, mobilenet));
       })
     )

--- a/web/pairplay.html
+++ b/web/pairplay.html
@@ -14,10 +14,16 @@
 
     <h1>ガンメンタイセン</h1>
 
-    <nav class="links">
-      <a href="index.html">1P</a>
-      <a href="pairplay.html">2P</a>
-    </nav>
+    <div class="menu">
+      <nav class="links">
+        <a href="index.html">1P</a>
+        <a href="pairplay.html">2P</a>
+      </nav>
+      <p class="records-container">
+        <a class="show-records disabled" href="#">タタカイノキロク</a>
+        <a class="clear-records disabled" href="#">（消去）</a>
+      </p>
+    </div>
 
     <select id="camera-selector"></select>
 
@@ -77,6 +83,23 @@
 
     <input class="robot-name" type="text">
 
+  </div>
+  <div class="overlay hidden">
+    <div class="modal">
+      <button class="previous-image" type="button">&lt;</button>
+      <button class="next-image" type="button">&gt;</button>
+      <div class="modal-footer">
+        <button class="toggle-left-image">Left</button>
+        <button class="share-image">
+          Share
+          <div class="loading-ring"></div>
+        </button>
+        <button class="toggle-right-image">Right</button>
+        <button class="close-qrcode">Back</button>
+      </div>
+      <canvas class="recorded-image-viewer" width="576" height="324"></canvas>
+      <div class="image-qrcode"></div>
+    </div>
   </div>
 
   <script src="./pairplay.ts"></script>

--- a/web/styles.css
+++ b/web/styles.css
@@ -82,10 +82,17 @@ select {
   border-color: var(--main-color);
 }
 
-.links {
+.menu {
   position: fixed;
   top: 20px;
   left: 20px;
+}
+
+.menu a:hover {
+  text-decoration: underline;
+}
+
+.links {
   padding: 0.5rem 1rem;
 }
 
@@ -93,8 +100,29 @@ select {
   color: var(--accent-color);
 }
 
-.links a:hover {
-  text-decoration: underline;
+.records-container {
+  margin: 0;
+  padding: 0.5rem 1rem;
+}
+
+.records-container a {
+  font-family: 'PixelMPlus', 'Courier New', Courier, monospace;
+}
+
+.show-records {
+  color: var(--main-color);
+  caret-color: var(--main-color);
+}
+
+.clear-records {
+  color: var(--accent-color);
+  caret-color: var(--accent-color);
+}
+
+.show-records.disabled, .clear-records.disabled {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.6;
 }
 
 #root {
@@ -116,7 +144,7 @@ select {
 
 .webcam-box {
   --box-border-color: rgb(32, 202, 117);
-  background-color: rgb(32, 202, 117, 0.2);
+  background-color: rgba(32, 202, 117, 0.2);
   border-width: 3px;
   border-style: solid;
   border-color: var(--box-border-color);
@@ -127,7 +155,7 @@ select {
 }
 
 .webcam-box.blink {
-  background-color: rgb(50, 93, 176	, 0.2);
+  background-color: rgba(50, 93, 176, 0.2);
   border-style: solid;
   border-color: var(--main-color);
   box-shadow: 0 0 50px #53FFE2;
@@ -142,4 +170,154 @@ select {
   height: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.5);
   min-width: 200px;
+}
+
+.overlay {
+  position: fixed;
+  z-index: 1;
+  padding-top: 30px;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.modal {
+  margin: auto;
+  width: 80%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+}
+
+.modal .image-qrcode {
+  display: none;
+  width: 100%;
+  min-height: 324px;
+  background-color: #fff;
+}
+.modal .close-qrcode {
+  display: none;
+}
+.modal.display-qrcode .image-qrcode {
+  display: flex;
+  justify-content: center;
+  align-items:center;
+}
+.modal.display-qrcode .previous-image,
+.modal.display-qrcode .next-image,
+.modal.display-qrcode .toggle-left-image,
+.modal.display-qrcode .toggle-right-image,
+.modal.display-qrcode .share-image,
+.modal.display-qrcode .recorded-image-viewer {
+  display: none;
+}
+.modal.display-qrcode .close-qrcode {
+  display: block;
+}
+
+.modal.hide-left-image .toggle-left-image {
+  text-decoration: line-through;
+}
+.modal.hide-right-image .toggle-right-image {
+  text-decoration: line-through;
+}
+
+.previous-image,
+.next-image {
+  color: #aaaaaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  position: absolute;
+  top: 50%;
+  margin-top: -30px;
+}
+
+.previous-image:hover,
+.previous-image:focus,
+.next-image:hover,
+.next-image:focus {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.previous-image {
+  left: -5%;
+}
+
+.next-image {
+  right: -5%;
+}
+
+.modal-footer {
+  position: absolute;
+  bottom: -3rem;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.modal-footer button {
+  font-size: 1.2rem;
+  padding: 0.5rem 1rem;
+  flex: 1;
+  margin: 0 0.5rem;
+  background-color: #000;
+}
+
+.recorded-image-viewer {
+  max-width: 100%;
+  max-height: 80vh;
+}
+
+.loading .loading-ring {
+  opacity: 1;
+  z-index: auto;
+}
+
+.loading-ring {
+  top: 50%;
+  right: auto;
+  position: absolute;
+  margin: -.6rem;
+  opacity: 0;
+  z-index: -100;
+  transition: all .3s;
+  transition-timing-function: ease-in;
+  animation: ld-cycle 1s infinite linear;
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.loading-ring:after {
+  box-sizing: border-box;
+  border-bottom-color: transparent!important;
+  border-radius: 50%;
+  border: .15rem solid;
+  content: " ";
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+}
+
+@keyframes ld-cycle {
+  0%,50%,to {
+    animation-timing-function: cubic-bezier(.5,.5,.5,.5)
+  }
+  0% {
+    transform: rotate(0)
+  }
+  50% {
+    transform: rotate(180deg)
+  }
+  to {
+    transform: rotate(360deg)
+  }
 }


### PR DESCRIPTION
Fixes #57 

プレイ中の画像を保存して共有できるようにしました。
プレイ中は、10秒に一回の頻度で画像を保存します。

画面左上の「タタカイノキロク」をクリックすると、

![2018-07-26 12 20 33](https://user-images.githubusercontent.com/3130879/43242787-f8cb82a6-90dd-11e8-9903-b5b0a00d0798.png)

共有用の画像が生成されてモーダルで表示されます。
社員が協力するケースがあるため、 "Left", "Right" ボタンでどちらか一方の顔画像だけを共有用画像に含めるようにすることもできます。

![2018-07-26 12 20 13](https://user-images.githubusercontent.com/3130879/43242834-3a1ce8f8-90de-11e8-80de-37d2e9a2172c.png)

"Share" ボタンを押すと、 Dropbox に画像をアップロードし、共有用の URL （4時間有効）を QR コードで表示します。

![2018-07-26 12 19 59](https://user-images.githubusercontent.com/3130879/43242882-6ec7ee90-90de-11e8-99b6-e7e522192fb1.png)
