### PR TITLE
Display connection status

### DIFF
--- a/robot/raspberrypi_client/mqtt_client.py
+++ b/robot/raspberrypi_client/mqtt_client.py
@@ -75,6 +75,7 @@ class MQTTClient(object):
         self.server_host = server_host
 
     def connect(self):
+        self.client.will_set("{}/connection".format(self.robot_name), payload=0, qos=1, retain=True)
         self.client.connect(self.server_host, 1883, 60)
 
         # Blocking call that processes network traffic, dispatches callbacks and
@@ -90,7 +91,6 @@ class MQTTClient(object):
         # reconnect then subscriptions will be renewed.
         client.subscribe("{}/right".format(self.robot_name), qos=1)
         client.subscribe("{}/left".format(self.robot_name), qos=1)
-        client.will_set("{}/connection".format(self.robot_name), payload=0, qos=1, retain=True)
         client.publish("{}/connection".format(self.robot_name), payload=1, qos=1, retain=True)
 
     # The callback for when a PUBLISH message is received from the server.

--- a/robot/raspberrypi_client/mqtt_client.py
+++ b/robot/raspberrypi_client/mqtt_client.py
@@ -90,6 +90,8 @@ class MQTTClient(object):
         # reconnect then subscriptions will be renewed.
         client.subscribe("{}/right".format(self.robot_name), qos=1)
         client.subscribe("{}/left".format(self.robot_name), qos=1)
+        client.will_set("{}/connection".format(self.robot_name), payload=0, qos=1, retain=True)
+        client.publish("{}/connection".format(self.robot_name), payload=1, qos=1, retain=True)
 
     # The callback for when a PUBLISH message is received from the server.
     def on_message(self, client, userdata, msg):
@@ -105,6 +107,7 @@ class MQTTClient(object):
         self.__del__()
 
     def __del__(self):
+        self.client.publish("{}/connection".format(self.robot_name), payload=0, qos=1, retain=True)
         self.client.disconnect()
         self.left_servo.__del__()
         self.right_servo.__del__()

--- a/web/keyEventHandler.ts
+++ b/web/keyEventHandler.ts
@@ -3,17 +3,19 @@ import { fromEvent, merge, Observable } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 import { VelocityTuner } from './velocityTuner';
 import { Command } from './classifier';
+import { MqttClient } from 'mqtt';
 
-export async function handleKeyEvent(
+export function handleKeyEvent(
+  mqttClient: MqttClient,
   robotName$: Observable<string>,
   velocityTuner: VelocityTuner
-): Promise<void> {
-  const [left, right] = await Promise.all(
-    ['left', 'right'].map(wheel =>
-      RobotController.createInstance(
+): void {
+  const [left, right] = ['left', 'right'].map(
+    wheel =>
+      new RobotController(
+        mqttClient,
         robotName$.pipe(map(robot => `${robot}/${wheel}`))
       )
-    )
   );
   let controlling = false;
   merge(

--- a/web/mqttClient.ts
+++ b/web/mqttClient.ts
@@ -1,0 +1,13 @@
+import { connect, MqttClient } from 'mqtt';
+
+export function getMqttClient(): Promise<MqttClient> {
+  const client = connect(`mqtt://${location.hostname}:9001`);
+  return new Promise((resolve, reject) =>
+    client
+      .on('connect', () => {
+        console.log('MQTT connected');
+        resolve(client);
+      })
+      .on('error', err => reject(err))
+  );
+}

--- a/web/pairplay.css
+++ b/web/pairplay.css
@@ -184,21 +184,25 @@ main {
 
 .robot-name {
   font-family: 'PixelMPlus', 'Courier New', Courier, monospace;
-  font-size: 1.2rem;
   margin: 24px 0;
   padding: 0.5rem 0.5rem;
   width: 216px;
   background: rgba(0, 0, 0, 0.15);
-  color: var(--main-color);
   border-color: var(--main-color);
   border-width: 2px;
   border-style: solid;
+  border-radius: 5px;
+  height: 108px;
+}
+
+.robot-name option:checked {
+  font-size: 1.2rem;
+  color: var(--main-color);
   caret-color: var(--main-color);
 }
 
-.robot-name:focus {
-  background: rgba(83, 255, 226, 0.2);
-  border-color: white;
+.robot-name option:not(.connected) {
+  text-decoration: line-through;
 }
 
 .modal-container {

--- a/web/pairplay.ts
+++ b/web/pairplay.ts
@@ -22,7 +22,7 @@ import {
   filter
 } from 'rxjs/operators';
 
-import { RobotController, RobotName } from './robot';
+import { observeConnection, RobotController, RobotName } from './robot';
 import {
   CameraSide,
   setupCamera,
@@ -550,6 +550,7 @@ const setupUI = async () => {
     fragment.appendChild(option);
   });
   robotNameSelect.appendChild(fragment);
+  robotNameSelect.size = robotNameSelect.children.length;
 
   robotNameSelect.value = robotName.value;
 
@@ -574,6 +575,15 @@ const setupUI = async () => {
 
   const velocityTuner = new VelocityTuner(robotName);
   handleKeyEvent(mqttClient, robotName, velocityTuner);
+
+  observeConnection(mqttClient).subscribe(robots => {
+    for (const option of robotNameSelect.children) {
+      option.classList.toggle(
+        'connected',
+        robots.indexOf((option as HTMLOptionElement).value as RobotName) >= 0
+      );
+    }
+  });
 
   classifierLeft.predictionResult$
     .pipe(

--- a/web/pairplay.ts
+++ b/web/pairplay.ts
@@ -50,8 +50,11 @@ const fullArea = {
 import { ImageRecorder } from './imageRecorder';
 import { VelocityTuner } from './velocityTuner';
 import { handleKeyEvent } from './keyEventHandler';
+import { getMqttClient } from './mqttClient';
+import { MqttClient } from 'mqtt';
 
 let mobilenet: tf.Model;
+let mqttClient: MqttClient;
 let robotControllerLeft: RobotController;
 let robotControllerRight: RobotController;
 let classifierLeft: Classifier;
@@ -557,18 +560,20 @@ const setupUI = async () => {
   const leftTopic$ = robotName.pipe(map(name => `${name}/left`));
   const rightTopic$ = robotName.pipe(map(name => `${name}/right`));
 
-  [mobilenet, robotControllerLeft, robotControllerRight] = await Promise.all([
+  [mobilenet, mqttClient] = await Promise.all([
     loadMobilenet(),
-    RobotController.createInstance(leftTopic$),
-    RobotController.createInstance(rightTopic$)
+    getMqttClient()
   ]);
+
+  robotControllerLeft = new RobotController(mqttClient, leftTopic$);
+  robotControllerRight = new RobotController(mqttClient, rightTopic$);
 
   const easyMode = !!Number(new URL(location.href).searchParams.get('easy'));
   classifierLeft = new Classifier(easyMode);
   classifierRight = new Classifier(easyMode);
 
   const velocityTuner = new VelocityTuner(robotName);
-  await handleKeyEvent(robotName, velocityTuner);
+  handleKeyEvent(mqttClient, robotName, velocityTuner);
 
   classifierLeft.predictionResult$
     .pipe(

--- a/web/robot.ts
+++ b/web/robot.ts
@@ -1,11 +1,11 @@
-import { connect, MqttClient } from 'mqtt';
+import { MqttClient } from 'mqtt';
 import { Observable, Subject } from 'rxjs';
-import { withLatestFrom } from 'rxjs/operators';
+import { distinctUntilChanged, scan, withLatestFrom } from 'rxjs/operators';
 
 export class RobotController {
   private velocity$ = new Subject<number>();
 
-  private constructor(client: MqttClient, topic$: Observable<string>) {
+  constructor(client: MqttClient, topic$: Observable<string>) {
     this.velocity$
       .pipe(withLatestFrom(topic$))
       .subscribe(([velocity, topic]) =>
@@ -13,21 +13,35 @@ export class RobotController {
       );
   }
 
-  static createInstance(topic$: Observable<string>): Promise<RobotController> {
-    const client = connect(`mqtt://${location.hostname}:9001`);
-    return new Promise((resolve, reject) =>
-      client
-        .on('connect', () => {
-          console.log('MQTT connected');
-          resolve(new RobotController(client, topic$));
-        })
-        .on('error', err => reject(err))
-    );
-  }
-
   setVelocity(velocity: number): void {
     this.velocity$.next(velocity);
   }
+}
+
+const CONNECTION_TOPIC_REGEXP = /^([^/]+)\/connection/;
+export function observeConnection(client: MqttClient): Observable<RobotName[]> {
+  client.subscribe('+/connection', { qos: 1 });
+  const update$ = new Subject<(robots: RobotName[]) => RobotName[]>();
+  client.on('message', (topic, payload) => {
+    const robot = topic.match(CONNECTION_TOPIC_REGEXP)![1] as RobotName;
+    update$.next(
+      (robots: RobotName[]) =>
+        Number(payload.toString())
+          ? robots.indexOf(robot) < 0
+            ? [...robots, robot].sort()
+            : robots
+          : robots.filter(_robot => _robot !== robot)
+    );
+  });
+  return update$.pipe(
+    scan<(robots: RobotName[]) => RobotName[], RobotName[]>(
+      (curr, updater) => updater(curr),
+      []
+    ),
+    distinctUntilChanged(
+      (a, b) => a.length === b.length && a.every((e, i) => e === b[i])
+    )
+  );
 }
 
 export enum RobotName {


### PR DESCRIPTION
Fixes #87 

https://github.com/eclipse/mosquitto/issues/622 の issue、よく見ると notification_topic は bridge のためのものだから will message を使えと言っていたので、 will message を使って実装しました。

robot 側は動作確認できていませんが https://github.com/eclipse/paho.mqtt.python を見て実装しました。

全ロボットの状態をリアルタイムで見たいということなので、とりあえず select で 全オプションを出すようにし、その中で繋がっていないものには打ち消し線をつけるようにしてみました。

![2018-08-03 13 21 15](https://user-images.githubusercontent.com/3130879/43624129-5dc34570-9720-11e8-9f79-283213888a5a.png)
