### PR TITLE
fix: ignore key event appropriately

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -120,19 +120,19 @@
             <tr>
               <td>前</td>
               <td>
-                <input type="number" data-target="left-forward">
+                <input type="number" data-target="left-forward" step="0.1">
               </td>
               <td>
-                <input type="number" data-target="right-forward">
+                <input type="number" data-target="right-forward" step="0.1">
               </td>
             </tr>
             <tr>
               <td>後</td>
               <td>
-                <input type="number" data-target="left-backward">
+                <input type="number" data-target="left-backward" step="0.1">
               </td>
               <td>
-                <input type="number" data-target="right-backward">
+                <input type="number" data-target="right-backward" step="0.1">
               </td>
             </tr>
           </tbody>

--- a/web/keyEventHandler.ts
+++ b/web/keyEventHandler.ts
@@ -20,6 +20,12 @@ export async function handleKeyEvent(
     fromEvent(document, 'keydown').pipe(
       filter(() => !controlling),
       map(({ key }: KeyboardEvent) => {
+        if (
+          document.activeElement instanceof HTMLInputElement ||
+          document.activeElement instanceof HTMLSelectElement
+        ) {
+          return undefined;
+        }
         switch (key) {
           case 'ArrowUp':
             return [Command.Forward, Command.Forward];


### PR DESCRIPTION
ロボット選択中やチューニング中に key イベントを拾わないように（意図せずロボットを動かさないように）しました。
ついでにチューニング時に矢印キーで 0.1 ずつ数字を変えられるようにしました。